### PR TITLE
Add Combine publishers for reading, writing, and executing queries in a transaction

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "CombineExtensions",
+        "repositoryURL": "https://github.com/shareup/combine-extensions.git",
+        "state": {
+          "branch": null,
+          "revision": "14a1e4e55d47b1a4cbb346acfe70450fc5868f54",
+          "version": "2.3.0"
+        }
+      },
+      {
         "package": "Synchronized",
         "repositoryURL": "https://github.com/shareup/synchronized.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/shareup/synchronized.git",
         "state": {
           "branch": null,
-          "revision": "e8bbab660d61b4f78fd94c3640f1a03886c326ea",
-          "version": "2.1.0"
+          "revision": "3843da8ff2af3e6c3fc30853ed473ba7630e7cfe",
+          "version": "2.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,16 @@ let package = Package(
             targets: ["SQLite"]),
     ],
     dependencies: [
-        .package(name: "Synchronized", url: "https://github.com/shareup/synchronized.git", from: "2.1.0")
+        .package(
+            name: "Synchronized",
+            url: "https://github.com/shareup/synchronized.git",
+            from: "2.1.0"
+        ),
+        .package(
+            name: "CombineExtensions",
+            url: "https://github.com/shareup/combine-extensions.git",
+            from: "2.3.0"
+        )
     ],
     targets: [
         .target(
@@ -23,6 +32,7 @@ let package = Package(
         .testTarget(
             name: "SQLiteTests",
             dependencies: [
+                .product(name: "CombineTestExtensions", package: "CombineExtensions"),
                 "SQLite",
             ]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(
             name: "Synchronized",
             url: "https://github.com/shareup/synchronized.git",
-            from: "2.1.0"
+            from: "2.2.0"
         ),
         .package(
             name: "CombineExtensions",

--- a/Sources/SQLite/SQLiteError.swift
+++ b/Sources/SQLite/SQLiteError.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SQLite3
 
-public enum SQLiteError: Error {
+public enum SQLiteError: Error, Equatable {
     case onInternalError(String)
     case onOpen(Int32, String)
     case onClose(Int32)
@@ -11,6 +11,9 @@ public enum SQLiteError: Error {
     case onStep(Int32, String)
     case onWrite(Array<SQLiteRow>)
     case onGetColumnType(Int32)
+    case onBeginTransactionAfterDeallocating
+    case onExecuteQueryWithoutOpenDatabase
+    case onExecuteQueryAfterDeallocating
     case onCreateFunction(String, Int32)
     case onRemoveFunction(String, Int32)
     case onGetColumnInTable(String)
@@ -44,12 +47,18 @@ extension SQLiteError: CustomStringConvertible {
             return "Could not get index for '\(parameterName)'"
         case .onBindParameter(let code, let index, let value):
             return "Could not bind \(value) to \(index): \(string(for: code))"
-        case .onStep(let code, let sql):
-            return "Could not execute SQL '\(sql)': \(string(for: code))"
+        case .onBeginTransactionAfterDeallocating:
+            return "Tried to begin a transaction after deallocating"
+        case .onExecuteQueryWithoutOpenDatabase:
+            return "Tried to execute a query without an open database connection"
+        case .onExecuteQueryAfterDeallocating:
+            return "Tried to execute a query after deallocating"
         case .onWrite(let result):
             return "Write returned results: '\(result)'"
         case .onGetColumnType(let type):
             return "Invalid column type: \(type)"
+        case .onStep(let code, let sql):
+            return "Could not execute SQL '\(sql)': \(string(for: code))"
         case .onCreateFunction(let name, let code):
             return "Could not create function '\(name)': \(string(for: code))"
         case .onRemoveFunction(let name, let code):

--- a/Sources/SQLite/SQLiteFuture.swift
+++ b/Sources/SQLite/SQLiteFuture.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Combine
+import Synchronized
+
+class SQLiteFuture<Output>: Publisher {
+    typealias Failure = SQLiteError
+
+    typealias Promise = (Result<Output, Failure>) -> Void
+
+    private enum State {
+        case notStarted((@escaping SQLiteFuture.Promise) -> Void)
+        case inProgress
+        case failed(SQLiteError)
+        case finished(Output)
+
+        var result: Result<Output, SQLiteError>? {
+            switch self {
+            case .notStarted, .inProgress:
+                return nil
+
+            case let .failed(error):
+                return .failure(error)
+
+            case let .finished(output):
+                return .success(output)
+            }
+        }
+    }
+
+    private var state: State
+    private var subscriptions = Set<SQLiteFutureSubscription<Output>>()
+    private var lock = RecursiveLock()
+
+    init(
+        _ attemptToFulfill: @escaping (@escaping Promise) -> Void
+    ) {
+        self.state = .notStarted(attemptToFulfill)
+    }
+
+    func receive<S: Subscriber>(
+        subscriber: S
+    ) where Failure == S.Failure, Output == S.Input {
+        let subscription = SQLiteFutureSubscription(
+            subscriber: subscriber,
+            resultProvider: resultProvider
+        )
+        lock.locked { let _ = subscriptions.insert(subscription) }
+        subscriber.receive(subscription: subscription)
+    }
+
+    private func notifySubscribers() {
+        lock.locked {
+            guard let result = state.result else { return }
+
+            var notified = Set<SQLiteFutureSubscription<Output>>()
+            for sub in subscriptions {
+                if sub.sendResult(result) {
+                    notified.insert(sub)
+                }
+            }
+            subscriptions.subtract(notified)
+        }
+    }
+
+    enum NextAction {
+        case doNothing
+        case attemptToFulfill((@escaping Promise) -> Void)
+        case sendOutput(Output)
+        case sendFailure(SQLiteError)
+    }
+
+    private var resultProvider: () -> Result<Output, SQLiteError>? {
+        { [weak self] in
+            guard let self = self else { return nil }
+
+            let nextAction = self.lock.locked { () -> NextAction in
+                switch self.state {
+                case let .notStarted(attemptToFulfill):
+                    self.state = .inProgress
+                    return .attemptToFulfill(attemptToFulfill)
+
+                case .inProgress:
+                    return .doNothing
+
+                case let .finished(output):
+                    return .sendOutput(output)
+
+                case let .failed(error):
+                    return .sendFailure(error)
+                }
+            }
+
+            switch nextAction {
+            case let .attemptToFulfill(attemptToFulfill):
+                // We can't use `[weak self]` here or the block
+                // will be deallocated immediately after invoked.
+                // This should not create a retain cycle because
+                // `self` does not retain the block.
+                attemptToFulfill({ result in
+                    self.lock.locked {
+                        guard case .inProgress = self.state else { return }
+
+                        switch result {
+                        case let .success(output):
+                            self.state = .finished(output)
+
+                        case let .failure(error):
+                            self.state = .failed(error)
+                        }
+                    }
+
+                    self.notifySubscribers()
+                })
+                return nil
+
+            case .doNothing:
+                return nil
+
+            case let .sendOutput(output):
+                return .success(output)
+
+            case let .sendFailure(error):
+                return .failure(error)
+            }
+        }
+    }
+}
+
+private final class SQLiteFutureSubscription<Output>: Subscription, Hashable {
+    let id: CombineIdentifier
+
+    private var hasDemand = false
+    private var subscriber: AnySubscriber<Output, SQLiteError>?
+    private let resultProvider: () -> Result<Output, SQLiteError>?
+    private let lock = RecursiveLock()
+
+    init<S: Subscriber>(
+        subscriber: S,
+        resultProvider: @escaping () -> Result<Output, SQLiteError>?
+    ) where S.Input == Output, S.Failure == SQLiteError {
+        self.id = subscriber.combineIdentifier
+        self.subscriber = AnySubscriber(subscriber)
+        self.resultProvider = resultProvider
+    }
+
+    deinit {
+        lock.locked { subscriber = nil }
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        guard demand != .none else { return }
+        lock.locked { self.hasDemand = true }
+        guard let result = resultProvider() else { return }
+        let _ = sendResult(result)
+    }
+
+    func cancel() {
+        lock.locked { subscriber = nil }
+    }
+
+    func sendResult(_ result: Result<Output, SQLiteError>) -> Bool {
+        lock.locked { () -> Bool in
+            // If we don't have any demand, we return `false` so that
+            // `SQLiteFuture` holds on to this subscription until it
+            // receives some demand and calls `resultProvider()`.
+            guard hasDemand else { return false }
+
+            // If we don't have a subscriber, we want to be removed from
+            // `SQLiteFuture`'s set of subscriptions. So, we need to
+            // return `true`.
+            guard let sub = subscriber else { return true }
+            subscriber = nil
+
+            switch result {
+            case let .success(output):
+                let _ = sub.receive(output)
+                sub.receive(completion: .finished)
+
+            case let .failure(error):
+                sub.receive(completion: .failure(error))
+            }
+
+            return true
+        }
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    static func == (lhs: SQLiteFutureSubscription, rhs: SQLiteFutureSubscription) -> Bool {
+        lhs.id == rhs.id
+    }
+}


### PR DESCRIPTION
This pull request adds Combine publishers for reading, writing, and executing queries in a transaction. All of these methods are implemented as asynchronous futures, which is a departure from the synchronous `read()`, `write()`, and `inTransaction()` methods. My goal is to move SQLite in a more asynchronous, reactive direction in the future. This will allow it to fit in better in the apps I'm writing and, moreover, add clean support for retrying requests in the case of `SQLITE_BUSY`.