### PR TITLE
Enable full-mutex (serialized) mode when opening database connections

### DIFF
--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -603,7 +603,8 @@ extension SQLiteDatabase {
 extension SQLiteDatabase {
     private class func open(at path: String) throws -> OpaquePointer {
         var optionalConnection: OpaquePointer?
-        let result = sqlite3_open(path, &optionalConnection)
+        let flags = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_FULLMUTEX
+        let result = sqlite3_open_v2(path, &optionalConnection, flags, nil)
 
         guard SQLITE_OK == result else {
             SQLiteDatabase.close(optionalConnection)


### PR DESCRIPTION
Apple compiles SQLite with "multi-thread" mode enabled, even though the SQLite default is "serialized" mode. We need every connection to be created in "serialized" mode because, even though all database access inside of SQLite is serialized onto a dedicated thread, if a Combine publisher fails, finalizing the publisher's SQLite statement occurs on whatever thread the publisher erred on, throwing an exception and potentially causing data loss. Better safe than sorry.

> **Multi-thread**. In this mode, SQLite can be safely used by multiple threads provided that no single database connection is used simultaneously in two or more threads.
>
> **Serialized**. In serialized mode, SQLite can be safely used by multiple threads with no restriction.
>
> [https://www.sqlite.org/threadsafe.html](https://www.sqlite.org/threadsafe.html)