### PR TITLE
Publish when deleting all rows in a table

### DIFF
--- a/Sources/SQLite/SQLiteResultsPublisher.swift
+++ b/Sources/SQLite/SQLiteResultsPublisher.swift
@@ -221,6 +221,9 @@ private final class SQLiteStatementResultsSubscription<S>: Subscription, Subscri
                 case let .updateTables(updatedTables):
                     guard !tables.isDisjoint(with: updatedTables) else { return nil }
                     return { self.publish() }
+
+                case .updateAllTables:
+                    return { self.publish() }
                 }
 
             case let .paused(subscription):

--- a/Tests/SQLiteTests/SQLitePublisherTests.swift
+++ b/Tests/SQLiteTests/SQLitePublisherTests.swift
@@ -185,6 +185,20 @@ class SQLitePublisherTests: XCTestCase {
         wait(for: [ex], timeout: 0.5)
     }
 
+    func testDeleteAll() throws {
+        let expected: Array<Array<Person>> = [
+            [_person1, _person2],
+            [],
+        ]
+
+        let ex = database
+            .publisher(Person.self, Person.getAll)
+            .expectOutput(expected)
+
+        try database.execute(raw: "DELETE FROM people;")
+        wait(for: [ex], timeout: 0.5)
+    }
+
     func testInsert() throws {
         let person3 = Person(id: "3", name: "New Human", age: 1, title: "newborn")
         let pet3 = Pet(name: "Camo the Camel", ownerID: person3.id, type: "camel", registrationID: "3")


### PR DESCRIPTION
This pull request fixes a problem in which database changes via `DELETE FROM <table>;` statements weren't published to subscribers because, for some unknown reason, the update hook is not called. Now, whenever the commit hook is called without the update hook first being called, we publish changes to all subscribers without caring about what tables they are interested in.