### PR TITLE
Fix QueryPlanParser for SQLite version 3.36.0 and above

### DIFF
--- a/Sources/SQLite/QueryPlanParser.swift
+++ b/Sources/SQLite/QueryPlanParser.swift
@@ -3,13 +3,14 @@ import Foundation
 struct QueryPlanParser {
     static func tables(
         in queryPlan: Array<SQLiteRow>,
-        matching databaseTables: Array<String>
+        matching databaseTables: Array<String>,
+        for sqliteVersion: SQLiteVersion
     ) -> Set<String> {
         let databaseTables = databaseTables.sortedByLongestToShortest()
         var tables = Set<String>()
         for row in queryPlan {
             guard let detail = row["detail"]?.stringValue else { continue }
-            guard let start = detail.tableNameStart else { continue }
+            guard let start = detail.tableNameStart(for: sqliteVersion) else { continue }
             guard let end = detail.tableNameEnd(startingAt: start, matching: databaseTables) else { continue }
             let table = detail[start..<end]
             guard table.isEmpty == false else { continue }
@@ -20,9 +21,22 @@ struct QueryPlanParser {
 }
 
 private extension String {
-    var tableNameStart: String.Index? {
-        guard hasPrefix("SCAN TABLE ") || hasPrefix("SEARCH TABLE ") else { return nil }
-        return range(of: " TABLE ")?.upperBound
+    func tableNameStart(for version: SQLiteVersion) -> String.Index? {
+        if version >= v3_24_0 && version < v3_36_0 {
+            guard hasPrefix("SCAN TABLE ") || hasPrefix("SEARCH TABLE ") else { return nil }
+            return range(of: " TABLE ")?.upperBound
+        } else if version >= v3_36_0 {
+            if hasPrefix("SCAN ") {
+                return range(of: "SCAN ")?.upperBound
+            } else if hasPrefix("SEARCH ") {
+                return range(of: "SEARCH ")?.upperBound
+            } else {
+                return nil
+            }
+        } else {
+            assertionFailure()
+            return nil
+        }
     }
 
     func tableNameEnd(
@@ -44,3 +58,6 @@ private extension Array where Element == String {
         return sorted(by: { $0.count > $1.count })
     }
 }
+
+private let v3_24_0 = SQLiteVersion(major: 3, minor: 24, patch: 0)
+private let v3_36_0 = SQLiteVersion(major: 3, minor: 36, patch: 0)

--- a/Sources/SQLite/SQLiteError.swift
+++ b/Sources/SQLite/SQLiteError.swift
@@ -8,6 +8,8 @@ public enum SQLiteError: Error, Equatable {
     case onOpenSharedDatabase(String, String)
     case onOpen(Int32, String)
     case onEnableWAL(Int32)
+    case onInvalidSQLiteVersion
+    case onUnsupportedSQLiteVersion(Int, Int, Int)
     case onClose(Int32)
     case onPrepareStatement(Int32, String)
     case onGetParameterIndex(String)
@@ -44,6 +46,10 @@ extension SQLiteError {
             return code
         case let .onEnableWAL(code):
             return code
+        case .onInvalidSQLiteVersion:
+            return nil
+        case .onUnsupportedSQLiteVersion:
+            return nil
         case let .onClose(code):
             return code
         case let .onPrepareStatement(code, _):
@@ -115,6 +121,10 @@ extension SQLiteError: CustomStringConvertible {
             return "Could not open database at '\(path)': \(string(for: code))"
         case let .onEnableWAL(code):
             return "Could not enable WAL mode: \(string(for: code))"
+        case .onInvalidSQLiteVersion:
+            return "Invalid SQLite version"
+        case let .onUnsupportedSQLiteVersion(major, minor, patch):
+            return "Unsupported SQLite version: \(major).\(minor).\(patch)"
         case .onClose(let code):
             return "Could not close database: \(string(for: code))"
         case .onPrepareStatement(let code, let sql):

--- a/Sources/SQLite/SQLiteStatement.swift
+++ b/Sources/SQLite/SQLiteStatement.swift
@@ -113,7 +113,11 @@ extension SQLiteStatement {
         guard let sql = sqlite3_sql(self) else { throw SQLiteError.onGetSQL }
         let explain = "EXPLAIN QUERY PLAN \(String(cString: sql));"
         let queryPlan = try database.execute(raw: explain)
-        return QueryPlanParser.tables(in: queryPlan, matching: try database.tables())
+        return QueryPlanParser.tables(
+            in: queryPlan,
+            matching: try database.tables(),
+            for: database.sqliteVersion
+        )
     }
 
     func reset() {

--- a/Sources/SQLite/SQLiteVersion.swift
+++ b/Sources/SQLite/SQLiteVersion.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+struct SQLiteVersion: Comparable {
+    let major: Int
+    let minor: Int
+    let patch: Int
+
+    init(major: Int, minor: Int, patch: Int) {
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+    }
+
+    init(rows: [SQLiteRow]) throws {
+        guard let row = rows.first,
+              let version = row["version"]?
+                .stringValue?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        else { throw SQLiteError.onInvalidSQLiteVersion }
+
+        let components = version.components(separatedBy: ".").compactMap(Int.init)
+        guard components.count == 3 else { throw SQLiteError.onInvalidSQLiteVersion }
+        major = components[0]
+        minor = components[1]
+        patch = components[2]
+    }
+
+    static var selectVersion: SQL { "SELECT sqlite_version() AS version;" }
+
+    static func == (lhs: SQLiteVersion, rhs: SQLiteVersion) -> Bool {
+        lhs.major == rhs.major && lhs.minor == rhs.minor && lhs.patch == rhs.patch
+    }
+
+    static func < (lhs: SQLiteVersion, rhs: SQLiteVersion) -> Bool {
+        guard lhs.major <= rhs.major else { return false }
+        guard lhs.major == rhs.major else {
+            // 2.x.x < 3.x.x
+            return true
+        }
+
+        guard lhs.minor <= rhs.minor else { return false }
+        guard lhs.minor == rhs.minor else {
+            // 3.2.x < 3.3.x
+            return true
+        }
+
+        return lhs.patch < rhs.patch
+    }
+
+    var isSupported: Bool {
+        self >= SQLiteVersion(major: 3, minor: 24, patch: 0) &&
+        self < SQLiteVersion(major: 4, minor: 0, patch: 0)
+    }
+}

--- a/Tests/SQLiteTests/QueryPlanParserTests.swift
+++ b/Tests/SQLiteTests/QueryPlanParserTests.swift
@@ -3,26 +3,45 @@ import SQLite3
 @testable import SQLite
 
 class QueryPlanParserTests: XCTestCase {
-    func testColumnsFromSingleTables() throws {
+    func testColumnsFromSingleTables_v3_24_0() throws {
         let tables = ["conversations", "TABLE", "SCAN"]
         let queryPlan: Array<SQLiteRow> = self.queryPlan([(1, 0, 0, "SCAN TABLE conversations")])
         let expected: Set<String> = ["conversations"]
-        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables)
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_24_0)
         XCTAssertEqual(expected, actual)
     }
 
-    func testColumnsFromMultipleTables() throws {
+    func testColumnsFromSingleTables_v3_36_0() throws {
+        let tables = ["conversations", "TABLE", "SCAN"]
+        let queryPlan: Array<SQLiteRow> = self.queryPlan([(1, 0, 0, "SCAN conversations")])
+        let expected: Set<String> = ["conversations"]
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_36_0)
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testColumnsFromMultipleTables_v3_24_0() throws {
         let tables = ["✌🏼 table", "first table", "sqlite_autoindex_✌🏼 table_1", "USING"]
         let queryPlan: Array<SQLiteRow> = self.queryPlan([
             (1, 0, 0, "SEARCH TABLE ✌🏼 table USING INDEX sqlite_autoindex_✌🏼 table_1 (id column=?)"),
             (4, 0, 0, "SEARCH TABLE first table USING INDEX sqlite_autoindex_first table_1 (id column=?)")
         ])
         let expected: Set<String> = ["first table", "✌🏼 table"]
-        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables)
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_24_0)
         XCTAssertEqual(expected, actual)
     }
 
-    func testColumnsWithMergesJoinsAndJSON() throws {
+    func testColumnsFromMultipleTables_v3_36_0() throws {
+        let tables = ["✌🏼 table", "first table", "sqlite_autoindex_✌🏼 table_1", "USING"]
+        let queryPlan: Array<SQLiteRow> = self.queryPlan([
+            (1, 0, 0, "SEARCH ✌🏼 table USING INDEX sqlite_autoindex_✌🏼 table_1 (id column=?)"),
+            (4, 0, 0, "SEARCH first table USING INDEX sqlite_autoindex_first table_1 (id column=?)")
+        ])
+        let expected: Set<String> = ["first table", "✌🏼 table"]
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_36_0)
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testColumnsWithMergesJoinsAndJSON_v3_24_0() throws {
         let tables = ["AS", "text_messages", "providers", "patients", "|||"]
         let queryPlan: Array<SQLiteRow> = self.queryPlan([
             (1, 0, 0, "MERGE (UNION ALL)"),
@@ -35,11 +54,28 @@ class QueryPlanParserTests: XCTestCase {
             (66, 52, 0, "SCAN TABLE json_each AS USING VIRTUAL TABLE INDEX 1:"),
         ])
         let expected: Set<String> = ["text_messages", "patients"]
-        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables)
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_24_0)
         XCTAssertEqual(expected, actual)
     }
 
-    func testColumnsWithSimilarNames() throws {
+    func testColumnsWithMergesJoinsAndJSON_v3_36_0() throws {
+        let tables = ["AS", "text_messages", "providers", "patients", "|||"]
+        let queryPlan: Array<SQLiteRow> = self.queryPlan([
+            (1, 0, 0, "MERGE (UNION ALL)"),
+            (3, 1, 0, "LEFT"),
+            (10, 3, 0, "SEARCH text_messages USING INDEX text_messages_index"),
+            (18, 3, 0, "SCAN patients"),
+            (27, 3, 0, "SCAN json_each AS USING VIRTUAL TABLE INDEX 1:"),
+            (52, 1, 0, "RIGHT"),
+            (62, 52, 0, "SEARCH text_messages USING CONVERING INDEX sqlite_autoindex_1"),
+            (66, 52, 0, "SCAN json_each AS USING VIRTUAL TABLE INDEX 1:"),
+        ])
+        let expected: Set<String> = ["text_messages", "patients"]
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_36_0)
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testColumnsWithSimilarNames_v3_24_0() throws {
         let tables = ["a", "ab", "abc", "abcd"]
         let queryPlan: Array<SQLiteRow> = self.queryPlan([
             (1, 0, 0, "SCAN TABLE a"),
@@ -47,11 +83,23 @@ class QueryPlanParserTests: XCTestCase {
             (10, 3, 0, "SEARCH TABLE ab USING INDEX ab_index"),
         ])
         let expected: Set<String> = ["a", "ab", "abcd"]
-        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables)
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_24_0)
         XCTAssertEqual(expected, actual)
     }
 
-    func testColumnsWithReservedWordsAndControlCharacters() throws {
+    func testColumnsWithSimilarNames_v3_36_0() throws {
+        let tables = ["a", "ab", "abc", "abcd"]
+        let queryPlan: Array<SQLiteRow> = self.queryPlan([
+            (1, 0, 0, "SCAN a"),
+            (3, 1, 0, "SCAN abcd"),
+            (10, 3, 0, "SEARCH ab USING INDEX ab_index"),
+        ])
+        let expected: Set<String> = ["a", "ab", "abcd"]
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_36_0)
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testColumnsWithReservedWordsAndControlCharacters_v3_24_0() throws {
         let tables = ["USING", "| |", "AS", "&&", "||", "USING AS"]
         let queryPlan: Array<SQLiteRow> = self.queryPlan([
             (1, 0, 0, "SEARCH TABLE USING AS USING USING_AS_index"),
@@ -59,7 +107,19 @@ class QueryPlanParserTests: XCTestCase {
             (10, 3, 0, "SEARCH TABLE | | USING INDEX ab_index"),
         ])
         let expected: Set<String> = ["USING AS", "&&", "| |"]
-        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables)
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_24_0)
+        XCTAssertEqual(expected, actual)
+    }
+
+    func testColumnsWithReservedWordsAndControlCharacters_v3_36_0() throws {
+        let tables = ["USING", "| |", "AS", "&&", "||", "USING AS"]
+        let queryPlan: Array<SQLiteRow> = self.queryPlan([
+            (1, 0, 0, "SEARCH USING AS USING USING_AS_index"),
+            (3, 1, 0, "SCAN &&"),
+            (10, 3, 0, "SEARCH | | USING INDEX ab_index"),
+        ])
+        let expected: Set<String> = ["USING AS", "&&", "| |"]
+        let actual = QueryPlanParser.tables(in: queryPlan, matching: tables, for: v3_36_0)
         XCTAssertEqual(expected, actual)
     }
 }
@@ -74,4 +134,7 @@ extension QueryPlanParserTests {
         return ["id": .integer(Int64(id)), "parent": .integer(Int64(parent)),
                 "notused": .integer(Int64(notused)), "detail": .text(detail)]
     }
+
+    private var v3_24_0: SQLiteVersion { .init(major: 3, minor: 24, patch: 0) }
+    private var v3_36_0: SQLiteVersion { .init(major: 3, minor: 36, patch: 0) }
 }

--- a/Tests/SQLiteTests/SQLiteVersionTests.swift
+++ b/Tests/SQLiteTests/SQLiteVersionTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import SQLite
+
+final class SQLiteVersionTests: XCTestCase {
+    func testInitWithRows() throws {
+        let valid: [SQLiteRow] = [["version": .text("3.35.5")]]
+
+        XCTAssertEqual(v3_35_5, try SQLiteVersion(rows: valid))
+        XCTAssertThrowsError(try SQLiteVersion(rows: [["Version": .text("3.35.5")]]))
+        XCTAssertThrowsError(try SQLiteVersion(rows: [["version": .text("35.5")]]))
+        XCTAssertThrowsError(try SQLiteVersion(rows: [["version": .text("35")]]))
+        XCTAssertThrowsError(try SQLiteVersion(rows: [["version": .text("3.3.35.5")]]))
+    }
+
+    func testEquatable() throws {
+        XCTAssertEqual(v3_36_0, v3_36_0)
+        XCTAssertEqual(v3_35_5, v3_35_5)
+        XCTAssertEqual(v3_24_0, v3_24_0)
+        XCTAssertEqual(v3_23_1, v3_23_1)
+
+        XCTAssertNotEqual(v4_35_5, v3_35_5)
+        XCTAssertNotEqual(v3_36_0, v3_35_5)
+        XCTAssertNotEqual(v3_35_5, v3_36_0)
+        XCTAssertNotEqual(v3_36_0, v3_24_0)
+        XCTAssertNotEqual(v3_36_0, v3_23_1)
+    }
+
+    func testComparable() throws {
+        XCTAssertTrue(v3_36_0 > v3_35_5)
+        XCTAssertFalse(v3_36_0 < v3_35_5)
+
+        XCTAssertFalse(v3_35_5 < v3_35_5)
+        XCTAssertTrue(v3_35_5 <= v3_35_5)
+
+        XCTAssertTrue(v3_23_1 > SQLiteVersion(major: 2, minor: 99, patch: 99))
+        XCTAssertFalse(v3_23_1 > SQLiteVersion(major: 3, minor: 23, patch: 99))
+    }
+
+    func testIsSupported() throws {
+        XCTAssertTrue(v3_36_0.isSupported)
+        XCTAssertTrue(v3_35_5.isSupported)
+        XCTAssertTrue(v3_24_0.isSupported)
+
+        XCTAssertFalse(v4_35_5.isSupported)
+        XCTAssertFalse(v3_23_1.isSupported)
+        XCTAssertFalse(SQLiteVersion(major: 1, minor: 24, patch: 0).isSupported)
+    }
+}
+
+private extension SQLiteVersionTests {
+    // Unsupported SQLite 4
+    var v4_35_5: SQLiteVersion {
+        .init(major: 4, minor: 35, patch: 5)
+    }
+
+    // Output of `EXPLAIN QUERY PLAN` changed with this version in iOS 15.
+    var v3_36_0: SQLiteVersion {
+        .init(major: 3, minor: 36, patch: 0)
+    }
+
+    // Last version before `EXPLAIN QUERY PLAN` output changes in `3.36.0`
+    var v3_35_5: SQLiteVersion {
+        .init(major: 3, minor: 35, patch: 5)
+    }
+
+    // First supported version
+    var v3_24_0: SQLiteVersion {
+        .init(major: 3, minor: 24, patch: 0)
+    }
+
+    // Unsupported version
+    var v3_23_1: SQLiteVersion {
+        .init(major: 3, minor: 23, patch: 1)
+    }
+}


### PR DESCRIPTION
This pull request adds support for parsing simple SQL queries using `QueryPlanParser` in SQLite version 3.36.0 and above. 

More complicated queries have not yet been tested. [An issue for this has been created](https://github.com/shareup/sqlite/issues/35) and should be looked into later.