### PR TITLE
Add touch() and async read, write, execute, and inTransaction methods

### DIFF
--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -438,12 +438,12 @@ public extension SQLiteDatabase {
 
 // MARK: - Trigger updates for observers
 
-extension SQLiteDatabase {
-    public func touch(_ tableName: String) {
+public extension SQLiteDatabase {
+    func touch(_ tableName: String) {
         touch([tableName])
     }
 
-    public func touch(_ tableNames: [String] = []) {
+    func touch(_ tableNames: [String] = []) {
         guard let actualTableNames = try? tables() else { return }
         let tableNamesToUpdate = Set(tableNames).intersection(actualTableNames)
         SQLiteQueue.sync {

--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -89,9 +89,10 @@ public final class SQLiteDatabase {
     }
 }
 
-// MARK: - Asynchronous queries
+// MARK: - Asynchronous queries - deprecated
 
 public extension SQLiteDatabase {
+    @available(*, deprecated, message: "Use Swift Concurrency")
     func inTransactionPublisher<T>(
         _ block: @escaping (SQLiteDatabase) throws -> T
     ) -> AnyPublisher<T, SQLiteError> {
@@ -115,6 +116,7 @@ public extension SQLiteDatabase {
         .eraseToAnyPublisher()
     }
 
+    @available(*, deprecated, message: "Use Swift Concurrency")
     func writePublisher(
         _ sql: SQL,
         arguments: SQLiteArguments = [:]
@@ -144,6 +146,7 @@ public extension SQLiteDatabase {
         .eraseToAnyPublisher()
     }
 
+    @available(*, deprecated, message: "Use Swift Concurrency")
     func readPublisher(
         _ sql: SQL,
         arguments: SQLiteArguments = [:]
@@ -165,6 +168,7 @@ public extension SQLiteDatabase {
         .eraseToAnyPublisher()
     }
 
+    @available(*, deprecated, message: "Use Swift Concurrency")
     func readPublisher<T: SQLiteTransformable>(
         _ sql: SQL,
         arguments: SQLiteArguments = [:]
@@ -179,6 +183,91 @@ public extension SQLiteDatabase {
                 }
             }
             .eraseToAnyPublisher()
+    }
+}
+
+// MARK: - Asynchronous queries
+
+public extension SQLiteDatabase {
+    func inTransaction<T>(
+        _ block: @escaping (SQLiteDatabase) throws -> T
+    ) async throws -> T {
+        try await withUnsafeThrowingContinuation { cont in
+            SQLiteQueue.async { [self] in
+                do {
+                    try Task.checkCancellation()
+                    let result = try self.inTransaction(block)
+                    cont.resume(returning: result)
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func write(_ sql: SQL, arguments: SQLiteArguments = [:]) async throws {
+        try await withUnsafeThrowingContinuation { cont in
+            SQLiteQueue.async { [self] in
+                do {
+                    try Task.checkCancellation()
+                    try self.write(sql, arguments: arguments)
+                    cont.resume()
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func read(
+        _ sql: SQL,
+        arguments: SQLiteArguments = [:]
+    ) async throws -> [SQLiteRow] {
+        try await withUnsafeThrowingContinuation { cont in
+            SQLiteQueue.async { [self] in
+                do {
+                    try Task.checkCancellation()
+                    let result = try self.read(sql, arguments: arguments)
+                    try Task.checkCancellation()
+                    cont.resume(returning: result)
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    func read<T: SQLiteTransformable>(
+        _ sql: SQL,
+        arguments: SQLiteArguments = [:]
+    ) async throws -> [T] {
+        try await withUnsafeThrowingContinuation { cont in
+            SQLiteQueue.async { [self] in
+                do {
+                    try Task.checkCancellation()
+                    let result: [T] = try self.read(sql, arguments: arguments)
+                    try Task.checkCancellation()
+                    cont.resume(returning: result)
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func execute(raw sql: SQL) async throws -> [SQLiteRow] {
+        try await withUnsafeThrowingContinuation { cont in
+            SQLiteQueue.async { [self] in
+                do {
+                    try Task.checkCancellation()
+                    let result = try self.execute(raw: sql)
+                    cont.resume(returning: result)
+                } catch {
+                    cont.resume(throwing: error)
+                }
+            }
+        }
     }
 }
 
@@ -347,6 +436,22 @@ public extension SQLiteDatabase {
     }
 }
 
+// MARK: - Trigger updates for observers
+
+extension SQLiteDatabase {
+    public func touch(_ tableName: String) {
+        touch([tableName])
+    }
+
+    public func touch(_ tableNames: [String] = []) {
+        guard let actualTableNames = try? tables() else { return }
+        let tableNamesToUpdate = Set(tableNames).intersection(actualTableNames)
+        SQLiteQueue.sync {
+            _changePublisher.publishChanges(for: tableNamesToUpdate)
+        }
+    }
+}
+
 // MARK: - Equatable
 
 extension SQLiteDatabase: Equatable {
@@ -359,11 +464,20 @@ extension SQLiteDatabase: Equatable {
 
 public extension SQLiteDatabase {
     var supportsJSON: Bool {
-        isCompileOptionEnabled("ENABLE_JSON1")
+        let isEnabled = isCompileOptionEnabled("SQLITE_ENABLE_JSON1")
+
+        guard let version = try? SQLiteVersion(self) else { return isEnabled }
+
+        // https://sqlite.org/compile.html#enable_json1
+        return version >= SQLiteVersion(major: 3, minor: 38, patch: 0) || isEnabled
+    }
+
+    var supportsPreupdateHook: Bool {
+        isCompileOptionEnabled("SQLITE_ENABLE_PREUPDATE_HOOK")
     }
 
     func isCompileOptionEnabled(_ name: String) -> Bool {
-        sqlite3_compileoption_used(name) == 1
+        sqlite3_compileoption_used(name) == Int32(1)
     }
 }
 

--- a/Sources/SQLite/SQLiteDatabaseChangePublisher.swift
+++ b/Sources/SQLite/SQLiteDatabaseChangePublisher.swift
@@ -60,6 +60,13 @@ final class SQLiteDatabaseChangePublisher: NSObject, Publisher {
         downstreamSubject.send(.close)
     }
 
+    func publishChanges(for tables: Set<String>) {
+        precondition(SQLiteQueue.isCurrentQueue)
+        notifyDownstreamSubscribersAsync(
+            tables.isEmpty ? .updateAllTables : .updateTables(tables)
+        )
+    }
+
     func receive<S: Subscriber>(
         subscriber: S
     ) where Failure == S.Failure, Output == S.Input {

--- a/Sources/SQLite/SQLiteVersion.swift
+++ b/Sources/SQLite/SQLiteVersion.swift
@@ -5,6 +5,10 @@ struct SQLiteVersion: Comparable {
     let minor: Int
     let patch: Int
 
+    init(_ database: SQLiteDatabase) throws {
+        try self.init(rows: database.execute(raw: Self.selectVersion))
+    }
+
     init(major: Int, minor: Int, patch: Int) {
         self.major = major
         self.minor = minor

--- a/Tests/SQLiteTests/SQLitePublisherTests.swift
+++ b/Tests/SQLiteTests/SQLitePublisherTests.swift
@@ -358,6 +358,63 @@ final class SQLitePublisherTests: XCTestCase {
 
         XCTAssertEqual(3, publishCount)
     }
+
+    func testTouchPublishesForSpecifiedTables() throws {
+        let peopleEx = database
+            .publisher(Person.self, Person.getAll, tables: ["people"])
+            .expectOutput([[_person1, _person2]], failsOnCompletion: true)
+
+        let petsEx = database
+            .publisher(Pet.self, Pet.getAll, tables: ["pets"])
+            .expectOutput([
+                [_pet1, _pet2],
+                [_pet1, _pet2],
+            ], failsOnCompletion: true)
+
+        database.touch("pets")
+
+        wait(for: [peopleEx, petsEx], timeout: 2)
+    }
+
+    func testTouchPublishesAllTablesWhenNoneAreSpecified() throws {
+        let peopleEx = database
+            .publisher(Person.self, Person.getAll, tables: ["people"])
+            .expectOutput([
+                [_person1, _person2],
+                [_person1, _person2],
+            ], failsOnCompletion: true)
+
+        let petsEx = database
+            .publisher(Pet.self, Pet.getAll, tables: ["pets"])
+            .expectOutput([
+                [_pet1, _pet2],
+                [_pet1, _pet2],
+            ], failsOnCompletion: true)
+
+        database.touch()
+
+        wait(for: [peopleEx, petsEx], timeout: 2)
+    }
+
+    func testTouchPublishesAllTablesWhenInvalidTableNamesAreSpecified() throws {
+        let peopleEx = database
+            .publisher(Person.self, Person.getAll, tables: ["people"])
+            .expectOutput([
+                [_person1, _person2],
+                [_person1, _person2],
+            ], failsOnCompletion: true)
+
+        let petsEx = database
+            .publisher(Pet.self, Pet.getAll, tables: ["pets"])
+            .expectOutput([
+                [_pet1, _pet2],
+                [_pet1, _pet2],
+            ], failsOnCompletion: true)
+
+        database.touch(["not-a-table", "👋"])
+
+        wait(for: [peopleEx, petsEx], timeout: 2)
+    }
 }
 
 extension SQLitePublisherTests {


### PR DESCRIPTION
- Add `SQLiteDatabase.touch()` to manually notify observers of changes not picked up by the [update hook](https://sqlite.org/c3ref/update_hook.html), such as `DELETE FROM <table name>;`
- Add async read, write, execute, and in-transaction methods to `SQLiteDatabase` and deprecate the Combine versions of those functions
- Update `supportsJSON` method to pass on newer versions of SQLite
- Add `supportsPreupdateHook` for eventual migration from the [update hook](https://sqlite.org/c3ref/update_hook.html) to the [pre-update hook](https://sqlite.org/c3ref/preupdate_blobwrite.html)