### PR TITLE
Use writeWithoutTransaction when appropriate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,9 @@ on: push
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: self-hosted
     
     steps:
       - uses: actions/checkout@v3
-      - name: Select Xcode 15
-        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Test
         run: swift test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,12 @@ on: push
 
 jobs:
   test:
-    runs-on: self-hosted
-    
+    runs-on: macos-13
+
     steps:
       - uses: actions/checkout@v3
+      - name: Select Xcode 15
+        run: sudo xcode-select -s /Applications/Xcode_15.0.app
       - name: Test
         run: swift test
+

--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -339,7 +339,7 @@ public extension SQLiteDatabase {
     @discardableResult
     func execute(raw sql: SQL) throws -> [SQLiteRow] {
         do {
-            return try database.writer.write { db in
+            return try database.writer.barrierWriteWithoutTransaction { db in
                 try db.execute(raw: sql)
             }
         } catch {
@@ -644,8 +644,7 @@ private extension SQLiteDatabase {
         config.journalMode = isInMemory ? .default : .wal
         // NOTE: GRDB recommends `defaultTransactionKind` be set
         //       to `.immediate` in order to prevent `SQLITE_BUSY`
-        //       errors. Using `.immediate` appears to disable
-        //       automatic vacuuming.
+        //       errors.
         //
         // https://swiftpackageindex.com/groue/grdb.swift/v6.24.2/documentation/grdb/databasesharing#How-to-limit-the-SQLITEBUSY-error
         config.defaultTransactionKind = .immediate

--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -648,9 +648,7 @@ private extension SQLiteDatabase {
         //       automatic vacuuming.
         //
         // https://swiftpackageindex.com/groue/grdb.swift/v6.24.2/documentation/grdb/databasesharing#How-to-limit-the-SQLITEBUSY-error
-        config.defaultTransactionKind = isInMemory
-            ? .deferred
-            : .immediate
+        config.defaultTransactionKind = .immediate
         config.busyMode = .timeout(busyTimeout)
         config.observesSuspensionNotifications = true
         config.maximumReaderCount = max(

--- a/Tests/SQLiteTests/SQLiteDatabaseTests.swift
+++ b/Tests/SQLiteTests/SQLiteDatabaseTests.swift
@@ -253,6 +253,27 @@ final class SQLiteDatabaseTests: XCTestCase {
         }
     }
 
+    func testCheckpointUsingTruncate() throws {
+        try Sandbox.execute { directory in
+            let path = directory.appendingPathComponent("test.db").path
+            let db = try SQLiteDatabase(path: path)
+            defer { try? db.close() }
+
+            try db.execute(raw: _createTableWithBlob)
+
+            try db.inTransaction { db in
+                for index in 0 ..< 100 {
+                    let args: SQLiteArguments = [
+                        "id": .integer(Int64(index)), "data": .data(_textData),
+                    ]
+                    try db.write(_insertIDAndData, arguments: args)
+                }
+            }
+
+            try db.truncate()
+        }
+    }
+
     func testCreateTable() throws {
         XCTAssertNoThrow(try database.execute(raw: _createTableWithBlob))
         let tableNames = try database.tables()


### PR DESCRIPTION
This pull request fixes `SQLITE_BUSY` errors caused by the shift to `IMMEDIATE` transactions.

Updating the [transaction type](https://sqlite.org/lang_transaction.html#deferred_immediate_and_exclusive_transactions) from the default `DEFERRED` to `IMMEDIATE` exposed some issues with the way SQLite wrapped GRDB. SQLite was wrapping some writes in an unnecessary transaction. This caused issues because `IMMEDIATE` transactions immediately begin a write, meaning other writes will receive a `SQLITE_BUSY` error. Before applying the changes in this pull request, vacuuming and checkpointing tests failed when `IMMEDIATE` transactions were used.

