### PR TITLE
Attempt to fix CI problems

### DIFF
--- a/Sources/SQLite/SQLiteDatabase.swift
+++ b/Sources/SQLite/SQLiteDatabase.swift
@@ -114,12 +114,12 @@ public final class SQLiteDatabase: DatabaseProtocol, @unchecked Sendable {
     public func truncate() throws {
         switch database {
         case let .pool(pool):
-            try pool.writeWithoutTransaction { db in
+            try pool.barrierWriteWithoutTransaction { db in
                 _ = try db.execute(raw: "PRAGMA wal_checkpoint(TRUNCATE);")
             }
 
         case let .queue(queue):
-            try queue.writeWithoutTransaction { db in
+            try queue.barrierWriteWithoutTransaction { db in
                 _ = try db.execute(raw: "PRAGMA wal_checkpoint(TRUNCATE);")
             }
         }
@@ -132,6 +132,7 @@ public final class SQLiteDatabase: DatabaseProtocol, @unchecked Sendable {
         switch database {
         case let .pool(pool):
             pool.interrupt()
+            pool.invalidateReadOnlyConnections()
             try pool.close()
 
         case let .queue(queue):


### PR DESCRIPTION
In an iOS app that consumes SQLite, migration tests have occasionally been failing with errors similiar to the following:

```
BUG IN CLIENT OF libsqlite3.dylib: database integrity compromised by API violation: vnode unlinked while in use
invalidated open fd
```

The errors mentioned the WAL or SHM files were being deleted before the database had been closed. The errors do not seem to be related to the content of the tests themselves. Instead, it seems like the migration tests have periodically started failing instead of the other database tests is the migration tests create databases on disk, whereas the other tests use in-memory databases. The databases are being created in a temporary directory and are not being manually deleted by the tests.

The tests started failing after moving to defaulting to `IMMEDIATE` transactions based on the [GRDB documentation](https://swiftpackageindex.com/groue/grdb.swift/v6.24.2/documentation/grdb/databasesharing#How-to-limit-the-SQLITEBUSY-error).

This pull request attempts to fix the flaky test failures by ensuring all reads and writes finish before truncation happens and the database is closed.